### PR TITLE
Added hotfixes module

### DIFF
--- a/hotfixes/hotfixes.cs3.5.cs
+++ b/hotfixes/hotfixes.cs3.5.cs
@@ -1,0 +1,1 @@
+hotfixes.cs4.cs

--- a/hotfixes/hotfixes.cs4.cs
+++ b/hotfixes/hotfixes.cs4.cs
@@ -1,0 +1,169 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Security;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+using System.Management;
+
+
+public class Module_hotfixes
+{
+    public const string SUCC_CODE       = "0";
+    public const string ERR_CODE        = "1";
+    public const string NON_TOKEN_VALUE = "0";
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern bool ImpersonateLoggedOnUser(IntPtr hToken);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern bool RevertToSelf();
+
+    private void ImpersonateWithToken(string token)
+    {
+        int token_int = Int32.Parse(token);
+        IntPtr targetToken = new IntPtr(token_int);
+
+        string current_username = "";
+        using (WindowsIdentity wid = WindowsIdentity.GetCurrent())
+        {
+            current_username = wid.Name;
+        }
+
+        if (!ImpersonateLoggedOnUser(targetToken))
+        {
+            var errorCode = Marshal.GetLastWin32Error();
+            throw new Exception("ImpersonateLoggedOnUser failed with the following error: " + errorCode);
+        }
+
+        string impersonate_username = "";
+        using (WindowsIdentity wid = WindowsIdentity.GetCurrent())
+        {
+            impersonate_username = wid.Name;
+        }
+
+        if (current_username == impersonate_username)
+            throw new Exception("ImpersonateLoggedOnUser worked, but thread running as user " + current_username);
+    }
+
+    private string hex2Str(string hex)
+    {
+        byte[] raw = new byte[hex.Length / 2];
+        for (int i = 0; i < raw.Length; i++)
+        {
+            raw[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        }
+        return Encoding.ASCII.GetString(raw);
+    }
+
+    private string normalizePath(string currPath)
+    {
+        currPath = currPath.Replace("\"", "");
+        currPath = currPath.Replace("'", "");
+        currPath = currPath.Replace(@"\", "/");
+        return currPath;
+    }
+
+    private string changeCWD(string cwd)
+    {
+        try
+        {
+            Directory.SetCurrentDirectory(cwd);
+            return normalizePath(Directory.GetCurrentDirectory());
+        }
+        catch (Exception ex)
+        {
+            if (ex is IOException)
+                throw new Exception("Path '" + cwd + "' is not a directory");
+            else if (ex is DirectoryNotFoundException)
+                throw new Exception("Directory '" + cwd + "' does not exist");
+            else if (ex is SecurityException)
+                throw new Exception("Directory '" + cwd + "' permission denied");
+            else if (ex is PathTooLongException)
+                throw new Exception("Path '" + cwd + "' exceed the maximum length defined by the system");
+            else
+                throw new Exception("Move to path '" + cwd + "' failed");
+        }
+    }
+
+    private string[] parseArguments(string args)
+    {
+        List<string> arguments_parsed = new List<string>();
+        string pattern = @"""[^""]+""|'[^']+'|\S+";
+        foreach (Match m in Regex.Matches(args, pattern))
+        {
+            arguments_parsed.Add(m.Value);
+        }
+        return arguments_parsed.ToArray();
+    }
+
+    private string[] doGetHotfixes()
+    {
+        string result = "HotFixID\tDescription\tInstalledOn" + Environment.NewLine;
+
+        try
+        {
+			string wmiQuery = "SELECT * FROM Win32_QuickFixEngineering";
+			ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiQuery);
+			ManagementObjectCollection results = searcher.Get();
+			
+			foreach (ManagementObject hotfix in results)
+			{
+				result += hotfix["HotFixID"].ToString() + "\t" + hotfix["Description"].ToString() + "\t" + hotfix["InstalledOn"].ToString() + Environment.NewLine;
+			}
+		}
+        catch(Exception ex)
+        {
+            result += ex.ToString() + Environment.NewLine;
+            return new string[]{ERR_CODE, result};
+        }
+
+        return new string[]{SUCC_CODE, result};
+    }
+
+    public string[] execute(string[] args)
+    {
+		return doGetHotfixes();
+    }
+
+    public string[] go(string cwd, string args, string token)
+    {
+        string[] results = new string[]{SUCC_CODE, ""};
+        string pwd = Directory.GetCurrentDirectory();
+
+        try
+        {
+            if (token != NON_TOKEN_VALUE)
+                ImpersonateWithToken(token);
+
+            string new_cwd = changeCWD(cwd);
+            string[] arguments_parsed = parseArguments(hex2Str(args));
+            
+            results = execute(arguments_parsed);
+        }
+        catch (Exception ex)
+        {
+            results[0] = ERR_CODE;
+            results[1] = ex.ToString();
+        }
+        finally
+        {
+            changeCWD(pwd);
+            if (token != NON_TOKEN_VALUE)
+                RevertToSelf();
+        }
+        return results;
+    }
+
+    public static void Main(string[] args)
+    {
+        Module_hotfixes m = new Module_hotfixes();
+        String[] results = m.execute(args);
+        Console.WriteLine(results[0]);
+        Console.WriteLine(results[1]);
+        return;
+    }
+}

--- a/modules.py
+++ b/modules.py
@@ -1238,5 +1238,26 @@ MODULE_COMMANDS = [
         ],
         "dispatcher" : "default",
         "formater" : "default"
-    }
+    },
+    {
+        "name" : "hotfixes",
+        "description" : "Show hotfixes installed on current computer (via WMI)",
+        "author" : "@the_etnum",
+        "template" : "hotfixes",
+        "examples" : [
+            "hotfixes"
+        ],
+        "so" : [
+            {
+                "name" : "Windows",
+                "agents" : ["cs"]
+            }
+        ],
+        "references" : [
+            "System.Management.dll"
+        ],
+        "args": [],
+        "dispatcher" : "default",
+        "formater" : "columns_header"
+    },
 ]


### PR DESCRIPTION
I have added a module for the Kraken **.NET agent** that allows to **list local hotfixes via WMI**. The module is **supported** in **.NET 3.5**, **.NET 4.0** and **probably higher**.

- The WMI query it performs: `SELECT * FROM Win32_QuickFixEngineering`. 
- The results are displayed in table format. 